### PR TITLE
fix timezone

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -193,14 +193,14 @@ var parsers = {
       // Check whether we are given the time (recent file) or the year
       // (older file) in the file listing.
       if (group[20].indexOf(":") === -1) {
-        date = +new Date(group[19] + " " + group[20]).getTime();
+        date = +new Date(group[19] + " " + group[20] + " UTC");
       }
       else {
         var currentMonth = new Date().getMonth();
         var month = new Date(group[19]).getMonth();
         var year = new Date().getFullYear() - (currentMonth < month ? 1 : 0);
 
-        date = +new Date(group[19] + " " + group[20] + " " + year);
+        date = +new Date(group[19] + " " + group[20] + " " + year + " UTC");
       }
 
       // Ignoring '.' and '..' entries for now


### PR DESCRIPTION
Calling `new Date("Mar 31 18:02 2021")` will interpret the date as being in the timezone of the local machine. When parsing FTP listings, these dates refer to the remote machine's timezone, which is unknown to us. Treat all dates as UTC and let the application layer transform to the correct timezone.

See also: https://github.com/nxtedition/nxt/pull/7100
Refs: https://github.com/nxtedition/nxt/issues/7093